### PR TITLE
Implement JWT authentication and authorization

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apollo/server": "^4.11.0",
         "@graphql-tools/merge": "^9.0.7",
+        "apollo-server": "^3.13.0",
         "apollo-server-core": "^3.13.0",
         "apollo-server-express": "^3.13.0",
         "bcrypt": "^5.1.1",
@@ -1513,6 +1514,21 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "license": "MIT"
     },
+    "node_modules/apollo-server": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-3.13.0.tgz",
+      "integrity": "sha512-hgT/MswNB5G1r+oBhggVX4Fjw53CFLqG15yB5sN+OrYkCVWF5YwPbJWHfSWa7699JMEXJGaoVfFzcvLZK0UlDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "4.17.14",
+        "apollo-server-core": "^3.13.0",
+        "apollo-server-express": "^3.13.0",
+        "express": "^4.17.1"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
     "node_modules/apollo-server-core": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.13.0.tgz",
@@ -1862,6 +1878,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/apollo-server/node_modules/@types/express": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/aproba": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@apollo/server": "^4.11.0",
     "@graphql-tools/merge": "^9.0.7",
+    "apollo-server": "^3.13.0",
     "apollo-server-core": "^3.13.0",
     "apollo-server-express": "^3.13.0",
     "bcrypt": "^5.1.1",

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -1,0 +1,20 @@
+import jwt from "jsonwebtoken";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const jwtSecret = process.env.JWT_SECRET || "yourSecretKey";
+
+export const generateToken = (userId: string, email: string): string => {
+  return jwt.sign({ userId, email }, jwtSecret, {
+    expiresIn: "1h",
+  });
+};
+
+export const verifyToken = (token: string): any => {
+  try {
+    return jwt.verify(token, jwtSecret);
+  } catch (error) {
+    throw new Error("Invalid or expired token");
+  }
+};

--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -1,0 +1,17 @@
+import { verifyToken } from "./auth";
+
+export const authMiddleware = (req: any, res: any, next: any) => {
+  const token = req.headers.authorization?.split(" ")[1];
+
+  if (!token) {
+    return res.status(401).json({ message: "Authorization required" });
+  }
+
+  try {
+    const decoded = verifyToken(token);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(403).json({ message: "Invalid token" });
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import { ApolloServer } from "apollo-server-express";
 import { typeDefs } from "./schema/typedefs/typeDefs";
 import resolvers from "./schema/resolvers/resolvers";
+import { verifyToken } from "./auth/auth";
 
 dotenv.config();
 
@@ -40,7 +41,19 @@ const startServer = async () => {
   const server = new ApolloServer({
     typeDefs,
     resolvers,
-    context: ({ req }) => ({ req }),
+    context: ({ req }) => {
+      const token = req.headers.authorization || "";
+      let user = null;
+
+      if (token) {
+        try {
+          user = verifyToken(token.replace("Bearer ", ""));
+        } catch (error) {
+          console.warn("Invalid or expired token");
+        }
+      }
+      return { user };
+    },
   });
 
   await server.start();

--- a/backend/src/schema/typedefs/userTypeDefs.ts
+++ b/backend/src/schema/typedefs/userTypeDefs.ts
@@ -1,5 +1,5 @@
 import { gql } from "apollo-server-express";
-import GraphQLJSON from "graphql-type-json";
+import { DirectiveLocation } from "graphql";
 
 export const userTypeDefs = gql`
   scalar Date
@@ -12,7 +12,7 @@ export const userTypeDefs = gql`
     diabates_type: Int
     email: String
     phone_number: String
-    password_token: String
+    password: String
     maximum_bsl: Float
     bsl_goal: Float
     footsteps_goal: Int
@@ -32,19 +32,27 @@ export const userTypeDefs = gql`
     active_status: Boolean
   }
 
+  type AuthPayload {
+    token: String!
+    user: User!
+  }
+
   type Query {
     getUser(id: ID!): User
     getUsers: [User!]!
   }
 
   type Mutation {
+    signUp(email: String!, password: String!): AuthPayload!
+    login(email: String!, password: String!): AuthPayload!
+
     createUser(
       name: String!
       age: Int
       diabates_type: Int
       email: String
       phone_number: String
-      password_token: String
+      password: String
       maximum_bsl: Float
       bsl_goal: Float
       footsteps_goal: Int
@@ -71,7 +79,7 @@ export const userTypeDefs = gql`
       diabates_type: Int
       email: String
       phone_number: String
-      password_token: String
+      password: String
       maximum_bsl: Float
       bsl_goal: Float
       footsteps_goal: Int


### PR DESCRIPTION
### Summary
Basic implementation of JWT auth. This is only for backend.

### Explanation
**JWT configurations**
- `/src/auth/auth.ts` gives tokenization and verification functionality. 
**Password hash with bcrypt**
- `/src/model/User.ts` defines middleware to hash password to store safely in db. It's run automatically whenever new user document is created. Also, you can find comparePassword method to match passwords in log-in. This will be used when login function is called.

**Controller**
- ` src/schema/resolvers/userResolvers.ts` navigates how to run in practice. Under the Mutation, you'll find 'singUp' and 'login'. Both of them generates access token as a result of function call. 

**Context on our root index.ts**
- The token is sent from the client via header. This token is verified. This is mainly used for authorization for query and mutation (update, delete...).

**Authorization in place**
- `getUser` in /`src/schema/resolvers/userResolvers.ts` is now protected. The highlighted parts in below screenshot is where such authorization is protected. This is the quickest way, however, I stop here as I should find more collective way to protect many query/mutations altogether.
<img width="436" alt="image" src="https://github.com/user-attachments/assets/7b0fb584-75f5-403d-99bb-c7f442e42043">


### How to test 
**Go to apollo server and play around
**Signup | authentication**
- execute this, for example
`mutation {
  signUp(email: "test@example.comm", password: "mypassword") {
    token
    user {
      email
    }
  }
}`
=>Then, access token is returned and you can find an user document created on mongoDB.

**login | authentication**
- execute this (up to user info on above 1)
`mutation {
  login(email: "test@example.com", password: "mypassword") {
    token
    user {
      email
    }
  }
}`
=>Then, you will see successful message on apollo server.

**route protection | authorization**
- execute this
`query {
  getUser(id: "USERID CREATED BY ABOVE 1") {
    email
  }
}`
=>Then, you will get error 'invalid or expired token'
- So, please add authorization header. the format is Bearer + <TOKEN>. Please copy a token from what you got in above 2. Then, you will successfully get query result for this time.
<img width="783" alt="image" src="https://github.com/user-attachments/assets/18d3aa14-d021-4517-8fdd-4216006ff9bf">

### Note
- As I mentioned above, currently only getUser query is protected. 
- Remaining tasks for backend are 1). Add refresh token 2). Collective authorization. It's too early to go such far and will come back week 7 when alpha is going to be ready.
- This is only about server side. When we interact with client, JWT token is normally delivered via cookie if it's web app, however, this is native mobile app so react-native has its own secure storage instead. For now, apollo server plays a role shortly for testing (like postman). In week5, I may come back to implement client side as well.