### PR TITLE
Add daily steps count for a user

### DIFF
--- a/backend/src/schema/resolvers/ActivityLogsResolvers.ts
+++ b/backend/src/schema/resolvers/ActivityLogsResolvers.ts
@@ -1,12 +1,9 @@
 import { ActivityLogs, IActivityLogs } from "../../model/ActivityLogs";
-import { Types, ObjectId } from "mongoose";
+import { Types } from "mongoose";
 
 const activityLogsResolvers = {
   Query: {
-    getActivityLog: async (
-      _: any,
-      { id }: { id: string }
-    ): Promise<IActivityLogs | null> => {
+    getActivityLog: async (_: any, { id }: { id: string }): Promise<IActivityLogs | null> => {
       return await ActivityLogs.findById(id);
     },
     getActivityLogs: async (): Promise<IActivityLogs[]> => {
@@ -15,26 +12,45 @@ const activityLogsResolvers = {
     getActivityLogsByUser: async (_: any, { user_id }: { user_id: string }) => {
       return await ActivityLogs.find({ user_id }).populate("user_id");
     },
+
+    // Query to get total footsteps for today for a specific user
+    getTotalStepsForToday: async (_: any, { user_id }: { user_id: string }): Promise<number> => {
+      const startOfDay = new Date();
+      startOfDay.setHours(0, 0, 0, 0); // Start of the day: 00:00:00
+
+      const endOfDay = new Date();
+      endOfDay.setHours(23, 59, 59, 999); // End of the day: 23:59:59
+
+      // MongoDB aggregation query to sum the footsteps for today
+      const result = await ActivityLogs.aggregate([
+        {
+          $match: {
+            user_id: new Types.ObjectId(user_id),
+            log_date: { $gte: startOfDay, $lt: endOfDay }  // Filter by today's date
+          }
+        },
+        {
+          $group: {
+            _id: null,  // No specific grouping, just sum for all logs for this user
+            totalFootsteps: { $sum: "$footsteps" }  // Sum the footsteps field
+          }
+        }
+      ]);
+
+      // If no activity logs exist for today, return 0
+      return result.length > 0 ? result[0].totalFootsteps : 0;
+    }
   },
+
   Mutation: {
-    createActivityLog: async (
-      _: any,
-      args: IActivityLogs
-    ): Promise<IActivityLogs> => {
+    createActivityLog: async (_: any, args: IActivityLogs): Promise<IActivityLogs> => {
       const newActivityLog = new ActivityLogs(args);
-      return (await newActivityLog.save()).populate("user_id");
+      return await newActivityLog.save();
     },
-    updateActivityLog: async (
-      _: any,
-      { id, ...args }: { id: string } & Partial<IActivityLogs>
-    ): Promise<IActivityLogs | null> => {
+    updateActivityLog: async (_: any, { id, ...args }: { id: string } & Partial<IActivityLogs>): Promise<IActivityLogs | null> => {
       return await ActivityLogs.findByIdAndUpdate(id, args, { new: true });
     },
-
-    deleteActivityLog: async (
-      _: any,
-      { id }: { id: string }
-    ): Promise<string> => {
+    deleteActivityLog: async (_: any, { id }: { id: string }): Promise<string> => {
       await ActivityLogs.findByIdAndDelete(id);
       return "ActivityLog deleted successfully";
     },

--- a/backend/src/schema/resolvers/ArticlesResolvers.ts
+++ b/backend/src/schema/resolvers/ArticlesResolvers.ts
@@ -5,22 +5,22 @@ const articlesResolvers = {
     getArticle: async (_: any, { id }: { id: string }): Promise<IArticles | null> => {
       return await Articles.findById(id);
     },
+    
     getArticles: async (): Promise<IArticles[]> => {
       return await Articles.find();
     },
   },
   Mutation: {
-    createArticle: async (_: any, args: IArticles): Promise<IArticles> => {
+    createArticle: async (_: any, args: Partial<IArticles>): Promise<IArticles> => {
       const newArticle = new Articles(args);
       return await newArticle.save();
-    },
+    },   
     updateArticle: async (
       _: any,
       { id, ...args }: { id: string } & Partial<IArticles>
     ): Promise<IArticles | null> => {
       return await Articles.findByIdAndUpdate(id, args, { new: true });
-    },
-
+    }, 
     deleteArticle: async (_: any, { id }: { id: string }): Promise<string> => {
       await Articles.findByIdAndDelete(id);
       return "Article deleted successfully";

--- a/backend/src/schema/typedefs/ActivityLogsTypeDefs.ts
+++ b/backend/src/schema/typedefs/ActivityLogsTypeDefs.ts
@@ -13,6 +13,8 @@ export const activityLogsTypeDefs = gql`
     getActivityLog(id: ID!): ActivityLogs
     getActivityLogs: [ActivityLogs!]!
     getActivityLogsByUser(user_id: ID!): [ActivityLogs!]!
+    getTotalStepsForToday(user_id: ID!): Int!
+
   }
 
   extend type Mutation {


### PR DESCRIPTION
This resolver query will return 'today' count of steps of a user which is needed to display in adding logs interface.

Can be tested for now using below query in appollo server..

query {
  getTotalStepsForToday(user_id: "66f8d1b096148884d92c29b4")
}

<img width="345" alt="image" src="https://github.com/user-attachments/assets/0e6f9fa1-9300-4596-8d81-a954652c70d7">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6ccefc64-ff39-4262-b1ad-f0af6e399286">
