### PR TITLE
Add resolver query to get average bsl value for the day of user

### DIFF
--- a/backend/src/schema/typedefs/testResultTypeDefs.ts
+++ b/backend/src/schema/typedefs/testResultTypeDefs.ts
@@ -18,6 +18,7 @@ export const testResultsTypeDefs = gql`
     getTestResult(id: ID!): TestResults
     getTestResults: [TestResults!]!
     getTestResultsByUser(user_id: ID!): [TestResults!]!
+    getAverageBslForToday(user_id: ID!): Float
   }
 
   extend type Mutation {


### PR DESCRIPTION
Summary

Created a graphQL query to get average bsl value for the day of user

Can be tested using this hardcorded userID for now in apollo server.

query {
  getAverageBslForToday(user_id: "60d8f33e7f3f83479cbf5b4f")
}

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ccf23d7f-8c6d-48be-98c0-00ad8b00d92a">
