### PR TITLE
Add resolver queries to test results

### DIFF
--- a/backend/src/model/ActivityLogs.ts
+++ b/backend/src/model/ActivityLogs.ts
@@ -3,14 +3,14 @@ import { Schema, model, Document, ObjectId } from "mongoose";
 export interface IActivityLogs extends Document {
   user_id: ObjectId;
   footsteps: number;
-  calorie_burnt: number;
+  duration: number;
   log_date: Date;
 }
 
 const activityLogsSchema = new Schema<IActivityLogs>({
   user_id: { type: Schema.Types.ObjectId, ref: "User", required: true },
   footsteps: { type: Number, required: true },
-  calorie_burnt: { type: Number, required: true },
+  duration: { type: Number, required: true },
   log_date: { type: Date, required: true },
 });
 

--- a/backend/src/model/User.ts
+++ b/backend/src/model/User.ts
@@ -34,6 +34,7 @@ export interface IUser extends Document {
   recently_read_articles_array: string[];
   active_status: boolean;
   favourite_articles: string[];
+  create_day: string;
   comparePassword: (password: string) => Promise<boolean>;
 }
 
@@ -69,8 +70,20 @@ const userSchema = new Schema<IUser>({
   read_article_history_array: {type: [String]},
   recently_read_articles_array: { type: [String] },
   active_status: { type: Boolean },
-  favourite_articles: {type: [String]}
+  favourite_articles: {type: [String]},
+  create_day: {type: String },
 });
+
+const dayMapping: { [key: number]: string } = {
+  0: "Sun",
+  1: "Mon",
+  2: "Tue",
+  3: "Wed",
+  4: "Thu",
+  5: "Fri",
+  6: "Sat",
+};
+
 
 // For signing up | hash the password before saving the user
 userSchema.pre<IUser>("save", async function (next) {
@@ -78,6 +91,12 @@ userSchema.pre<IUser>("save", async function (next) {
 
   const salt = await bcrypt.genSalt(10);
   this.password = await bcrypt.hash(this.password, salt);
+
+  // Calculate the creation day (e.g., "Wed")
+  const currentDate = new Date();
+  const dayOfWeek = currentDate.getDay(); // Get the numeric day of the week
+  this.create_day = dayMapping[dayOfWeek];
+
   next();
 });
 

--- a/backend/src/schema/resolvers/ActivityLogsResolvers.ts
+++ b/backend/src/schema/resolvers/ActivityLogsResolvers.ts
@@ -39,7 +39,28 @@ const activityLogsResolvers = {
 
       // If no activity logs exist for today, return 0
       return result.length > 0 ? result[0].totalFootsteps : 0;
-    }
+    },
+
+    getTodayActivityLogs: async (_: any, { user_id }: { user_id: string }): Promise<IActivityLogs[]> => {
+      try {
+        const startOfDay = new Date();
+        startOfDay.setHours(0, 0, 0, 0); // Set to start of today
+
+        const endOfDay = new Date();
+        endOfDay.setHours(23, 59, 59, 999); // Set to end of today
+
+        // Fetch all activity logs for today
+        const todayActivityLogs = await ActivityLogs.find({
+          user_id: new Types.ObjectId(user_id),
+          log_date: { $gte: startOfDay, $lte: endOfDay },
+        });
+
+        return todayActivityLogs;
+      } catch (error) {
+        console.error("Error fetching today's activity logs:", error);
+        throw new Error("Failed to fetch today's activity logs");
+      }
+    },
   },
 
   Mutation: {

--- a/backend/src/schema/resolvers/DietLogsResolvers.ts
+++ b/backend/src/schema/resolvers/DietLogsResolvers.ts
@@ -8,6 +8,26 @@ const dietLogsResolvers = {
     getDietLogs: async (_: any, { userID }: { userID: string }): Promise<IDietLogs[]> => {
       return await DietLogs.find({ userID });
     },
+    getTodayDietLogs: async (_: any, { userID }: { userID: string }): Promise<IDietLogs[]> => {
+      try {
+        const startOfDay = new Date();
+        startOfDay.setHours(0, 0, 0, 0); // Set to start of today
+
+        const endOfDay = new Date();
+        endOfDay.setHours(23, 59, 59, 999); // Set to end of today
+
+        // Fetch all diet logs for today
+        const todayDietLogs = await DietLogs.find({
+          userID: userID,
+          logDateTime: { $gte: startOfDay, $lte: endOfDay },
+        });
+
+        return todayDietLogs;
+      } catch (error) {
+        console.error("Error fetching today's diet logs:", error);
+        throw new Error("Failed to fetch today's diet logs");
+      }
+    },
   },
   Mutation: {
     createDietLog: async (_: any, args: IDietLogs): Promise<IDietLogs> => {

--- a/backend/src/schema/resolvers/MedicineLogResolvers.ts
+++ b/backend/src/schema/resolvers/MedicineLogResolvers.ts
@@ -15,6 +15,26 @@ const medicineLogResolvers = {
     getMedicineLogsByUser: async (_: any, { user_id }: { user_id: string }) => {
       return await MedicineLog.find({ user_id }).populate("user_id");
     },
+   // Get today's medicine logs for a specific user
+   getTodayMedicineLogs: async (_: any, { user_id }: { user_id: string }): Promise<IMedicineLog[]> => {
+    try {
+      const startOfDay = new Date();
+      startOfDay.setHours(0, 0, 0, 0); // Start of today
+
+      const endOfDay = new Date();
+      endOfDay.setHours(23, 59, 59, 999); // End of today
+
+      // Fetch all medicine logs for today
+      return await MedicineLog.find({
+        user_id: new Types.ObjectId(user_id),
+        injection_time: { $gte: startOfDay, $lte: endOfDay },
+      });
+    } catch (error) {
+      console.error("Error fetching today's medicine logs:", error);
+      throw new Error("Failed to fetch today's medicine logs");
+    }
+  },
+    
   },
   Mutation: {
     createMedicineLog: async (

--- a/backend/src/schema/typedefs/ActivityLogsTypeDefs.ts
+++ b/backend/src/schema/typedefs/ActivityLogsTypeDefs.ts
@@ -5,7 +5,7 @@ export const activityLogsTypeDefs = gql`
     id: ID!
     user_id: User!  # Linked to User
     footsteps: Int!
-    calorie_burnt: Int!
+    duration: Int!
     log_date: Date!
   }
 
@@ -14,21 +14,21 @@ export const activityLogsTypeDefs = gql`
     getActivityLogs: [ActivityLogs!]!
     getActivityLogsByUser(user_id: ID!): [ActivityLogs!]!
     getTotalStepsForToday(user_id: ID!): Int!
-
+    getTodayActivityLogs(user_id: ID!): [ActivityLogs!]!
   }
 
   extend type Mutation {
     createActivityLog(
       user_id: ID!
       footsteps: Int!
-      calorie_burnt: Int!
+      duration: Int!
       log_date: Date!
     ): ActivityLogs!
 
     updateActivityLog(
       id: ID!
       footsteps: Int
-      calorie_burnt: Int
+      duration: Int
       log_date: Date
     ): ActivityLogs!
 

--- a/backend/src/schema/typedefs/DietLogsTypeDefs.ts
+++ b/backend/src/schema/typedefs/DietLogsTypeDefs.ts
@@ -6,12 +6,13 @@ export const dietLogsTypeDefs = gql`
     userID: String!
     note: String
     calorieTaken: Float!
-    logDateTime: String!
+    logDateTime: Date!
   }
 
   extend type Query {
     getDietLog(id: ID!): DietLog
     getDietLogs(userID: String!): [DietLog!]!
+    getTodayDietLogs(userID: ID!): [DietLog!]!
   }
 
   extend type Mutation {
@@ -19,7 +20,7 @@ export const dietLogsTypeDefs = gql`
       userID: String!
       note: String
       calorieTaken: Float!
-      logDateTime: String!
+      logDateTime: Date!
     ): DietLog!
 
     updateDietLog(

--- a/backend/src/schema/typedefs/MedicineLogTypeDefs.ts
+++ b/backend/src/schema/typedefs/MedicineLogTypeDefs.ts
@@ -12,6 +12,7 @@ export const medicineLogTypeDefs = gql`
     getMedicineLog(id: ID!): MedicineLog
     getMedicineLogs: [MedicineLog!]!
     getMedicineLogsByUser(user_id: ID!): [MedicineLog!]!
+    getTodayMedicineLogs(user_id: ID!): [MedicineLog!]!
   }
 
   extend type Mutation {
@@ -25,6 +26,7 @@ export const medicineLogTypeDefs = gql`
       id: ID!
       amount: Float
       injection_time: Date
+      time_period: String
     ): MedicineLog!
 
     deleteMedicineLog(id: ID!): String!

--- a/backend/src/schema/typedefs/testResultTypeDefs.ts
+++ b/backend/src/schema/typedefs/testResultTypeDefs.ts
@@ -14,13 +14,29 @@ export const testResultsTypeDefs = gql`
     note_description: String
   }
 
+  type TestResultsAndAverage {
+    testResults: [TestResults!]!
+    averageBsl: Float
+  }  
+
+  type WeeklyBSLResponse {
+    weeklyData: [BSLData!]!
+    weeklyAverage: Float!
+  }
+  
+  type BSLData {
+    day: String!
+    value: Float!
+  }
+
   extend type Query {
     getTestResult(id: ID!): TestResults
     getTestResults: [TestResults!]!
     getTestResultsByUser(user_id: ID!): [TestResults!]!
     getUnconfirmedTestResults(user_id: ID!): [TestResults!]!
-    getAverageBslForToday(user_id: ID!): Float
-  }
+    getTestResultsAndAverageForToday(user_id: ID!): TestResultsAndAverage!
+    getWeeklyBSLData(user_id: ID!): WeeklyBSLResponse!
+    }
 
   extend type Mutation {
     createTestResult(

--- a/backend/src/schema/typedefs/userTypeDefs.ts
+++ b/backend/src/schema/typedefs/userTypeDefs.ts
@@ -31,6 +31,7 @@ export const userTypeDefs = gql`
     badges: JSON
     recently_read_articles_array: [String]
     active_status: Boolean
+    create_day: String
   }
 
   type AuthPayload {
@@ -75,6 +76,7 @@ export const userTypeDefs = gql`
       recently_read_articles_array: [String]
       active_status: Boolean
       favourite_articles: [String]
+      create_day: String
     ): User!
 
     updateUser(
@@ -106,6 +108,7 @@ export const userTypeDefs = gql`
       recently_read_articles_array: [String]
       active_status: Boolean
       favourite_articles: [String]
+      create_day: String
     ): User!
 
     deleteUser(id: ID!): String!


### PR DESCRIPTION
1. Query to get all the today's test result logs of the user 

- getTestResultsAndAverageForToday is testResultResolvers.ts

3. Query to get each kind of today's logs of the user (activity, medicine, carbs) - 

- getTodayActivityLogs in ActivityLogsResolvers.ts 
- getTodayDietLogs in DietLogsResolvers.ts
- getTodayMedicineLogs in MedicinelogResolvers.ts

4. Query to get BSL data weekly

-getWeeklyBSLData in testResultsResolvers.ts

ex: [ { day: "Wed", value: 80 }, { day: "Thu", value: 40 }, { day: "Fri", value: 100 } ]  (value is daily average)
calculate and return the average BSL value of the week too

note: starting day of the week should be the day on which the user registered to our app(it gets from user collection create_day) currently 3rd query can be tested with 670702cbd3ce55c634ec740c

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/7b9aa2b4-702f-4459-a99f-27a1e93677bf">
