### PR TITLE
feat: JDEV-78 | Create a resolver for activity log

### DIFF
--- a/backend/src/schema/resolvers/ActivityLogsResolvers.ts
+++ b/backend/src/schema/resolvers/ActivityLogsResolvers.ts
@@ -1,9 +1,13 @@
 import { ActivityLogs, IActivityLogs } from "../../model/ActivityLogs";
 import { Types } from "mongoose";
+import moment from "moment-timezone";
 
 const activityLogsResolvers = {
   Query: {
-    getActivityLog: async (_: any, { id }: { id: string }): Promise<IActivityLogs | null> => {
+    getActivityLog: async (
+      _: any,
+      { id }: { id: string }
+    ): Promise<IActivityLogs | null> => {
       return await ActivityLogs.findById(id);
     },
     getActivityLogs: async (): Promise<IActivityLogs[]> => {
@@ -14,7 +18,10 @@ const activityLogsResolvers = {
     },
 
     // Query to get total footsteps for today for a specific user
-    getTotalStepsForToday: async (_: any, { user_id }: { user_id: string }): Promise<number> => {
+    getTotalStepsForToday: async (
+      _: any,
+      { user_id }: { user_id: string }
+    ): Promise<number> => {
       const startOfDay = new Date();
       startOfDay.setHours(0, 0, 0, 0); // Start of the day: 00:00:00
 
@@ -26,22 +33,25 @@ const activityLogsResolvers = {
         {
           $match: {
             user_id: new Types.ObjectId(user_id),
-            log_timestamp: { $gte: startOfDay, $lt: endOfDay }  // Filter by today's date
-          }
+            log_timestamp: { $gte: startOfDay, $lt: endOfDay }, // Filter by today's date
+          },
         },
         {
           $group: {
-            _id: null,  // No specific grouping, just sum for all logs for this user
-            totalFootsteps: { $sum: "$footsteps" }  // Sum the footsteps field
-          }
-        }
+            _id: null, // No specific grouping, just sum for all logs for this user
+            totalFootsteps: { $sum: "$footsteps" }, // Sum the footsteps field
+          },
+        },
       ]);
 
       // If no activity logs exist for today, return 0
       return result.length > 0 ? result[0].totalFootsteps : 0;
     },
 
-    getTodayActivityLogs: async (_: any, { user_id }: { user_id: string }): Promise<IActivityLogs[]> => {
+    getTodayActivityLogs: async (
+      _: any,
+      { user_id }: { user_id: string }
+    ): Promise<IActivityLogs[]> => {
       try {
         const startOfDay = new Date();
         startOfDay.setHours(0, 0, 0, 0); // Set to start of today
@@ -61,17 +71,99 @@ const activityLogsResolvers = {
         throw new Error("Failed to fetch today's activity logs");
       }
     },
+    getStreakActivityLogs: async (
+      _: any,
+      { user_id }: { user_id: string }
+    ): Promise<number> => {
+      try {
+        // Fetch activity logs for the user
+        const activityLogs = await ActivityLogs.find({
+          user_id: new Types.ObjectId(user_id),
+        })
+          .sort({ log_timestamp: 1 })
+          .exec();
+
+        if (!activityLogs.length) return 0;
+
+        const days = new Set<string>();
+
+        activityLogs.forEach((log) => {
+          const utcDate = moment.utc(log.log_timestamp).format("YYYY-MM-DD");
+          days.add(utcDate);
+        });
+
+        const uniqueDays = Array.from(days).sort();
+        const today = moment.tz("America/Vancouver").startOf("day");
+        const yesterday = moment
+          .tz("America/Vancouver")
+          .subtract(1, "days")
+          .startOf("day");
+
+        let streak = 0;
+        let currentStreak = 0;
+
+        for (let i = uniqueDays.length - 1; i >= 0; i--) {
+          const currentDay = moment.utc(uniqueDays[i], "YYYY-MM-DD");
+
+          if (i === uniqueDays.length - 1) {
+            const diffFromToday = today.diff(currentDay, "days");
+            const diffFromYesterday = yesterday.diff(currentDay, "days");
+
+            console.log(
+              `Checking first log day (UTC): ${uniqueDays[i]} (diffFromToday: ${diffFromToday}, diffFromYesterday: ${diffFromYesterday})`
+            );
+
+            if (diffFromToday === 0) {
+              currentStreak = 1;
+            } else if (diffFromYesterday === 0) {
+              currentStreak = 1;
+            } else {
+              return 0;
+            }
+          } else {
+            const prevDay = moment.utc(uniqueDays[i + 1], "YYYY-MM-DD");
+            const diff = prevDay.diff(currentDay, "days");
+
+            if (diff === 1) {
+              currentStreak++;
+            } else {
+              break;
+            }
+          }
+          streak = Math.max(streak, currentStreak);
+        }
+
+        return streak;
+      } catch (error) {
+        console.error(
+          "Error calculating streak of consecutive activity logs:",
+          error
+        );
+        throw new Error(
+          "Failed to calculate streak of consecutive activity logs"
+        );
+      }
+    },
   },
 
   Mutation: {
-    createActivityLog: async (_: any, args: IActivityLogs): Promise<IActivityLogs> => {
+    createActivityLog: async (
+      _: any,
+      args: IActivityLogs
+    ): Promise<IActivityLogs> => {
       const newActivityLog = new ActivityLogs(args);
       return await newActivityLog.save();
     },
-    updateActivityLog: async (_: any, { id, ...args }: { id: string } & Partial<IActivityLogs>): Promise<IActivityLogs | null> => {
+    updateActivityLog: async (
+      _: any,
+      { id, ...args }: { id: string } & Partial<IActivityLogs>
+    ): Promise<IActivityLogs | null> => {
       return await ActivityLogs.findByIdAndUpdate(id, args, { new: true });
     },
-    deleteActivityLog: async (_: any, { id }: { id: string }): Promise<string> => {
+    deleteActivityLog: async (
+      _: any,
+      { id }: { id: string }
+    ): Promise<string> => {
       await ActivityLogs.findByIdAndDelete(id);
       return "ActivityLog deleted successfully";
     },

--- a/backend/src/schema/resolvers/testResultResolvers.ts
+++ b/backend/src/schema/resolvers/testResultResolvers.ts
@@ -176,12 +176,11 @@ const testResultsResolvers = {
             ? parseFloat((totalBSL / results.length).toFixed(1))
             : 0; // Round to 1 decimal
 
-               // Format the start and end dates in the format: "Sep 24 - Oct 30, 2024"
-    const formattedStartDate = format(startOfWeek, "MMM dd");
-    const formattedEndDate = format(endOfWeek, "MMM dd, yyyy");
+        // Format the start and end dates in the format: "Sep 24 - Oct 30, 2024"
+        const formattedStartDate = format(startOfWeek, "MMM dd");
+        const formattedEndDate = format(endOfWeek, "MMM dd, yyyy");
 
-    const dateRange = `${formattedStartDate} - ${formattedEndDate}`;
-
+        const dateRange = `${formattedStartDate} - ${formattedEndDate}`;
 
         return {
           weeklyData: formattedData,
@@ -259,8 +258,11 @@ const testResultsResolvers = {
         });
 
         const uniqueDays = Array.from(days).sort();
-        const today = moment.utc().startOf("day");
-        const yesterday = moment.utc().subtract(1, "days").startOf("day");
+        const today = moment.tz("America/Vancouver").startOf("day");
+        const yesterday = moment
+          .tz("America/Vancouver")
+          .subtract(1, "days")
+          .startOf("day");
 
         let streak = 0;
         let currentStreak = 0;

--- a/backend/src/schema/typedefs/ActivityLogsTypeDefs.ts
+++ b/backend/src/schema/typedefs/ActivityLogsTypeDefs.ts
@@ -3,10 +3,10 @@ import { gql } from "apollo-server-express";
 export const activityLogsTypeDefs = gql`
   type ActivityLogs {
     id: ID!
-    user_id: User!  # Linked to User
+    user_id: User! # Linked to User
     footsteps: Int
     duration: Int!
-    time_period : String
+    time_period: String
     log_timestamp: Date!
   }
 
@@ -16,6 +16,7 @@ export const activityLogsTypeDefs = gql`
     getActivityLogsByUser(user_id: ID!): [ActivityLogs!]!
     getTotalStepsForToday(user_id: ID!): Int!
     getTodayActivityLogs(user_id: ID!): [ActivityLogs!]!
+    getStreakActivityLogs(user_id: ID!): Int!
   }
 
   extend type Mutation {
@@ -23,7 +24,7 @@ export const activityLogsTypeDefs = gql`
       user_id: ID!
       footsteps: Int
       duration: Int!
-      time_period : String
+      time_period: String
       log_timestamp: Date!
     ): ActivityLogs!
 
@@ -31,7 +32,7 @@ export const activityLogsTypeDefs = gql`
       id: ID!
       footsteps: Int
       duration: Int
-      time_period : String
+      time_period: String
       log_timestamp: Date
     ): ActivityLogs!
 


### PR DESCRIPTION
## Summary
Created a simple resolver to calc streak of activity log.

## Changes
- Create a new resolver called getStreakActicityLog.
- I have noticed a timezone issue also in getStreakTestResults, so fixed together through this pr.

## Sample query
```
query {
  getStreakActivityLogs(user_id: "670702cbd3ce55c634ec740c") 
}
```