### PR TITLE
Retrieve Articles with Favorite Status

### DIFF
--- a/backend/src/schema/typedefs/ArticleTypeDefs.ts
+++ b/backend/src/schema/typedefs/ArticleTypeDefs.ts
@@ -9,6 +9,7 @@ export const articlesTypeDefs = gql`
     article_url: String!
     article_genre: String!
     diabetes_type: String!
+    isFavorite: Boolean!
   }
 
   type ArticlesConnection {
@@ -42,9 +43,9 @@ export const articlesTypeDefs = gql`
   }
 
   extend type Query {
-    getArticle(id: ID!): Articles
+    getArticle(id: ID!, userId: ID!): Articles
     getArticles: [Articles!]!
-    getAllArticlesPagination(cursor: String, limit: Int): ArticlesConnection
+    getAllArticlesPagination(cursor: String, limit: Int, userId: ID!): ArticlesConnection
     getUserArticlesPagination(
       userId: ID!
       cursor: String


### PR DESCRIPTION
Summary
The resolver checks if the articleId exists in the favourite_articles array of the user's document in the database. If the articleId is found in the user's favourite_articles array, the isFavorite field in the response is set to true. If the articleId is not found, isFavorite is set to false.

How to test
Toggle favaourite article
mutation {
  toggleFavouriteArticle(userId: "6713c70982539a6394424088", articleId: "671345982b9e701fbf58706c") {
    message
  }
}

Then,

query {
  getArticle(id: "671345982b9e701fbf58706c", userId: "6713c70982539a6394424088") {
    article_name
    article_desc
    article_genre
    isFavorite
  }
}

When we test it again, it shows the different result

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c505c399-861f-4100-820a-e8cada7bacc9">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6da1a9a5-9de9-48c0-b76c-98dc5e1657ae">
