### PR TITLE
Fixing to retrieve favourite articles when loading articles

### DIFF
--- a/backend/src/schema/resolvers/ArticlesResolvers.ts
+++ b/backend/src/schema/resolvers/ArticlesResolvers.ts
@@ -35,101 +35,111 @@ const articlesResolvers = {
       if (!article) {
         return null;
       }
-
-      // Check if the article is in user's favorites
+    
+      // Check if the article is in the user's favorites
       const user = await User.findById(userId);
       const isFavorite = user ? user.favourite_articles.includes(id) : false;
-
-      // Return the article with isFavorite flag
-      return { ...article.toObject(), isFavorite } as IArticlesWithFavorite;
+    
+      // Return the article with the `id` field and `isFavorite` flag
+      return { 
+        ...article.toObject(), 
+        id: article._id.toString(), // Ensure `id` field is set
+        isFavorite 
+      } as IArticlesWithFavorite;
     },
+    
 
 
     getArticles: async (): Promise<IArticles[]> => {
       return await Articles.find();
     },
-
-      getAllArticlesPagination: async (
-        _: any,
-        { cursor, limit, userId }: { cursor?: string; limit?: number; userId: string }
-      ): Promise<ArticlesConnection> => {
-        const defaultLimit = 10;
-        const startIndex = cursor ? parseInt(cursor) : 0;
-        const itemsPerPage = limit || defaultLimit;
-  
-        const articles = await Articles.find()
-          .skip(startIndex)
-          .limit(itemsPerPage)
-          .exec();
-  
-        const user = await User.findById(userId);
-        const favouriteArticles = user ? user.favourite_articles : [];
-  
-        const articlesWithFavorite: IArticlesWithFavorite[] = articles.map((article) => ({
-          ...article.toObject(),
-          isFavorite: favouriteArticles.includes(article._id.toString()),
-        })) as IArticlesWithFavorite[];
-  
-        const hasNextPage = articles.length === itemsPerPage;
-        const newCursor = hasNextPage ? (startIndex + itemsPerPage).toString() : null;
-  
-        return {
-          edges: articlesWithFavorite,
-          pageInfo: {
-            hasNextPage,
-            endCursor: newCursor,
-          },
-        };
-      },
-      getUserArticlesPagination: async (
-        _: any,
-        { userId, cursor, limit, classification }: GetInsightsArgs
-      ): Promise<ArticlesConnection> => {
-        const defaultLimit = 10;
-        const user = await User.findById(userId);
-        if (!user) {
-          throw new Error("User not found");
-        }
-  
-        let articleIds: string[];
-        if (classification === "recent") {
-          articleIds = user.recently_read_articles_array;
-        } else if (classification === "favorite") {
-          articleIds = user.favourite_articles;
-        } else {
-          articleIds = [];
-        }
-  
-        const startIndex = cursor ? parseInt(cursor) : 0;
-        const itemsPerPage = limit || defaultLimit;
-        const paginatedIds = articleIds.slice(startIndex, startIndex + itemsPerPage);
-  
-        const articles = await Articles.find({
-          _id: { $in: paginatedIds },
-        }).exec();
-  
-        // Add 'isFavorite' field to each article
-        const articlesWithFavorite: IArticlesWithFavorite[] = paginatedIds.map((id) => {
+    getAllArticlesPagination: async (
+      _: any,
+      { cursor, limit, userId }: { cursor?: string; limit?: number; userId: string }
+    ): Promise<ArticlesConnection> => {
+      const defaultLimit = 10;
+      const startIndex = cursor ? parseInt(cursor) : 0;
+      const itemsPerPage = limit || defaultLimit;
+    
+      const articles = await Articles.find()
+        .skip(startIndex)
+        .limit(itemsPerPage)
+        .exec();
+    
+      const user = await User.findById(userId);
+      const favouriteArticles = user ? user.favourite_articles : [];
+    
+      const articlesWithFavorite: IArticlesWithFavorite[] = articles.map((article) => ({
+        id: article._id.toString(), // Ensure ID is a string
+        ...article.toObject(),
+        isFavorite: favouriteArticles.includes(article._id.toString()),
+      })) as IArticlesWithFavorite[];
+    
+      const hasNextPage = articles.length === itemsPerPage;
+      const newCursor = hasNextPage ? (startIndex + itemsPerPage).toString() : null;
+    
+      return {
+        edges: articlesWithFavorite,
+        pageInfo: {
+          hasNextPage,
+          endCursor: newCursor,
+        },
+      };
+    },
+    getUserArticlesPagination: async (
+      _: any,
+      { userId, cursor, limit, classification }: GetInsightsArgs
+    ): Promise<ArticlesConnection> => {
+      const defaultLimit = 10;
+      const user = await User.findById(userId);
+      if (!user) {
+        throw new Error("User not found");
+      }
+    
+      let articleIds: string[];
+      if (classification === "recent") {
+        articleIds = user.recently_read_articles_array;
+      } else if (classification === "favorite") {
+        articleIds = user.favourite_articles;
+      } else {
+        articleIds = [];
+      }
+    
+      const startIndex = cursor ? parseInt(cursor) : 0;
+      const itemsPerPage = limit || defaultLimit;
+      const paginatedIds = articleIds.slice(startIndex, startIndex + itemsPerPage);
+    
+      const articles = await Articles.find({
+        _id: { $in: paginatedIds },
+      }).exec();
+    
+      // Add 'isFavorite' field and ensure 'id' is a string
+      const articlesWithFavorite: IArticlesWithFavorite[] = paginatedIds
+        .map((id) => {
           const article = articles.find((a) => a._id.toString() === id.toString());
           if (!article) return null;
-  
+    
           return {
+            id: article._id.toString(), // Explicitly set 'id' as a string
             ...article.toObject(),
             isFavorite: user.favourite_articles.includes(id),
           };
-        }).filter(Boolean) as IArticlesWithFavorite[];
-  
-        const hasNextPage = startIndex + itemsPerPage < articleIds.length;
-        const newCursor = hasNextPage ? (startIndex + itemsPerPage).toString() : null;
-  
-        return {
-          edges: articlesWithFavorite,
-          pageInfo: {
-            hasNextPage,
-            endCursor: newCursor,
-          },
-        };
-      },
+        })
+        .filter(Boolean) as IArticlesWithFavorite[];
+    
+      const hasNextPage = startIndex + itemsPerPage < articleIds.length;
+      const newCursor = hasNextPage ? (startIndex + itemsPerPage).toString() : null;
+    
+      return {
+        edges: articlesWithFavorite,
+        pageInfo: {
+          hasNextPage,
+          endCursor: newCursor,
+        },
+      };
+    },    
+    
+    
   },
   Mutation: {
     createArticle: async (


### PR DESCRIPTION
Summary
Added id: article._id.toString() to the getArticle, getAllArticlesPagination and getUserArticlesPagination queries.

How to test

query {
  getArticle(id: "671345982b9e701fbf58706c", userId: "6713c70982539a6394424088") {
    id
    article_name
    isFavorite
  }
}

query {
  getUserArticlesPagination(userId: "6713c70982539a6394424088", cursor: "0", limit: 5, classification: "favorite") {
    edges {
      id
      article_name
      article_desc
      article_genre
      isFavorite
    }
    pageInfo {
      hasNextPage
      endCursor
    }
  }
}

query GetAllArticlesPagination {
  getAllArticlesPagination(cursor: "0", limit: 5, userId: "6713c70982539a6394424088") {
    edges {
      id
      article_name
      article_desc
      article_genre
      isFavorite
    }
    pageInfo {
      hasNextPage
      endCursor
    }
  }
}